### PR TITLE
Fix the order of Planship constructor args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,18 @@ install-dev:
 	-python3 -m pip install -e planship_openapi_gen
 	-python3 -m pip install -e planship
 
+.PHONY: build
+build:
+	-rm -rf planship_openapi_gen/dist planship/dist planship_openapi_gen/build planship/build
+	-python3 -m build planship_openapi_gen
+	-python3 -m build planship
+
+
+.PHONY: deploy
+deploy:
+	-twine upload planship_openapi_gen/dist/*
+	-twine upload planship/dist/*
+
 .PHONY: isort
 isort:  ## Run isort on the package.
 	-isort --check-only planship

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # planship-python
 
-Welcome to the Python client for the Planship API.
+Welcome to the Python client for [Planship](https://planship.io).
 
 ## Installation and basic usage
 
@@ -18,31 +18,35 @@ Import and instantiate the `Planship` class, and start making calls to the Plans
 from planship import Planship
 
 planship = Planship(
-    "clicker-demo", # Planship product slug
-    "https://api.planship.io", # Planship API endpoint URL
-    "273N1SQ3GQFZ8JSFKIOK", # Planship API client ID
-    "GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX" # Planship API client secret
+    "clicker-demo",                         # Planship product slug
+    "https://api.planship.io",              # Planship API endpoint URL
+    "273N1SQ3GQFZ8JSFKIOK",                 # Planship API client ID
+    "GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX"      # Planship API client secret
 )
 
-# list product plans
+# List product plans
 plans = planship.list_plans()
 
-# create a customer with a name and email
+# Create a customer with a name and email
 customer = planship.create_customer({
     "name": "Darth Vader",
     "email:": "vader@empire.gov"
 })
 
-# subscribe the customer to a plan
+# Subscribe the customer with a given ID to a plan with a slug "medium"
 subscription = planship.create_subscription(customer.id, "medium")
 
-# retrieve customer entitlements
+# Retrieve entitlements for a customer with a give ID
 entitlements = planship.get_entitlements(customer.id)
 
-# report usage for a customer
+# Report usage for a customer with given ID for a given metering ID
 planship.report_usage(customer.id, "api-call", 11)
 ```
 
-## Complete reference
-
 The complete reference for the `Planship` class can be found [here](./docs/content/planship-class.md).
+
+## Links
+
+- [Planship documentation](https://docs.planship.io)
+- [Planship Python client at PyPI](https://pypi.org/project/planship/)
+- [Planship Console sign-up](https://app.planship.io/auth/sign-up)

--- a/planship/README.md
+++ b/planship/README.md
@@ -1,6 +1,6 @@
 # planship-python
 
-Welcome to the Python client for the Planship API.
+Welcome to the Python client for [Planship](https://planship.io).
 
 ## Installation and basic usage
 
@@ -18,31 +18,35 @@ Import and instantiate the `Planship` class, and start making calls to the Plans
 from planship import Planship
 
 planship = Planship(
-    "clicker", # Planship product slug
-    "https://api.planship.io", # Planship API endpoint URL
-    "273N1SQ3GQFZ8JSFKIOK", # Planship API client ID
-    "GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX" # Planship API client secret
+    "clicker-demo",                         # Planship product slug
+    "https://api.planship.io",              # Planship API endpoint URL
+    "273N1SQ3GQFZ8JSFKIOK",                 # Planship API client ID
+    "GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX"      # Planship API client secret
 )
 
-# list product plans
+# List product plans
 plans = planship.list_plans()
 
-# create a customer with a name and email
+# Create a customer with a name and email
 customer = planship.create_customer({
     "name": "Darth Vader",
     "email:": "vader@empire.gov"
 })
 
-# subscribe the customer to a plan
+# Subscribe the customer with a given ID to a plan with a slug "medium"
 subscription = planship.create_subscription(customer.id, "medium")
 
-# retrieve customer entitlements
+# Retrieve entitlements for a customer with a give ID
 entitlements = planship.get_entitlements(customer.id)
 
-# report usage for a customer
+# Report usage for a customer with given ID for a given metering ID
 planship.report_usage(customer.id, "api-call", 11)
 ```
 
-## Complete reference
-
 The complete reference for the `Planship` class can be found [here](./docs/content/planship-class.md).
+
+## Links
+
+- [Planship documentation](https://docs.planship.io)
+- [Planship Python client at PyPI](https://pypi.org/project/planship/)
+- [Planship Console sign-up](https://app.planship.io/auth/sign-up)

--- a/planship/planship/planship.py
+++ b/planship/planship/planship.py
@@ -2,11 +2,11 @@ from typing import Dict, List, Optional
 
 from planship_openapi_gen.api import (
     CustomersApi,
+    CustomerSubscriptionsApi,
     EntitlementsApi,
     MeteredUsageApi,
     ProductsApi,
     SubscriptionCustomersApi,
-    CustomerSubscriptionsApi,
 )
 from planship_openapi_gen.models import (
     Customer,
@@ -38,12 +38,12 @@ from .models import (
 
 
 class Planship(Base):
-    def __init__(self, url: str, product_slug: str, client_id: str, client_secret: str):
+    def __init__(self, product_slug: str, url: str, client_id: str, client_secret: str):
         """Create an instance of the Planship API client class
 
         Args:
-            url (str): Planship API service endpoint URL (E.g. https://api.planship.io)
             product_slug (str): Planship product slug
+            url (str): Planship API service endpoint URL (E.g. https://api.planship.io)
             client_id (str): Planship API client ID
             client_secret (str): Planship API client secret
         """
@@ -142,7 +142,9 @@ class Planship(Base):
         Returns:
             CustomerSubscriptionWithPlan: Instance of the CustomerSubscriptionWithPlan class
         """
-        return self.get_api_instance(CustomerSubscriptionsApi).get_customer_plan_subscription(
+        return self.get_api_instance(
+            CustomerSubscriptionsApi
+        ).get_customer_plan_subscription(
             customer_id,
             subscription_id,
         )
@@ -294,7 +296,9 @@ class Planship(Base):
         Returns:
             List[CustomerSubscriptionWithPlan]: List of instances of the CustomerSubscriptionWithPlan class
         """
-        return self.get_api_instance(CustomerSubscriptionsApi).list_customer_plan_subscriptions(
+        return self.get_api_instance(
+            CustomerSubscriptionsApi
+        ).list_customer_plan_subscriptions(
             customer_id,
         )
 

--- a/planship/setup.py
+++ b/planship/setup.py
@@ -6,7 +6,7 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 NAME = "planship"
-VERSION = "0.0.2"
+VERSION = "0.1.1"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
This PR, when merged, will change the order of Planship class constructor arguments so it is aligned with other Planship API client libraries (product slug, API endpoint URL, client ID and client secret).

Other changes include minor tweaks to the README file and build/deploy commands in the Makefile.