### PR TITLE
Make the API URL argument optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ deploy:
 	-twine upload planship_openapi_gen/dist/*
 	-twine upload planship/dist/*
 
+.PHONY: test-deploy
+test-deploy: build
+	-twine upload --repository testpypi planship_openapi_gen/dist/*
+	-twine upload --repository testpypi planship/dist/*
+
 .PHONY: isort
 isort:  ## Run isort on the package.
 	-isort --check-only planship

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # planship-python
 
-Welcome to the Python client for [Planship](https://planship.io).
+Welcome to the Python client for the [Planship API](https://docs.planship.io/integration). [Planship](https://planship.io) enables developers to build subscription logic for product pricing based on any combination of features, seats, and usage.
+
 
 ## Installation and basic usage
 
@@ -19,7 +20,6 @@ from planship import Planship
 
 planship = Planship(
     "clicker-demo",                         # Planship product slug
-    "https://api.planship.io",              # Planship API endpoint URL
     "273N1SQ3GQFZ8JSFKIOK",                 # Planship API client ID
     "GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX"      # Planship API client secret
 )
@@ -33,20 +33,21 @@ customer = planship.create_customer({
     "email:": "vader@empire.gov"
 })
 
-# Subscribe the customer with a given ID to a plan with a slug "medium"
+# Subscribe the customer to a plan with the slug "medium"
 subscription = planship.create_subscription(customer.id, "medium")
 
-# Retrieve entitlements for a customer with a give ID
+# Retrieve entitlements for the customer
 entitlements = planship.get_entitlements(customer.id)
 
-# Report usage for a customer with given ID for a given metering ID
+# Report 11 units of usage for the "api-call" metering ID for the customer
 planship.report_usage(customer.id, "api-call", 11)
 ```
 
-The complete reference for the `Planship` class can be found [here](./docs/content/planship-class.md).
+The complete reference for the `Planship` class can be found [here](https://github.com/planship/planship-python/blob/master/docs/content/planship-class.md).
 
 ## Links
 
 - [Planship documentation](https://docs.planship.io)
+- [Sign up for Planship](https://app.planship.io/auth/sign-up)
+- [Planship Python client class reference](https://github.com/planship/planship-python/blob/master/docs/content/planship-class.md)
 - [Planship Python client at PyPI](https://pypi.org/project/planship/)
-- [Planship Console sign-up](https://app.planship.io/auth/sign-up)

--- a/planship/README.md
+++ b/planship/README.md
@@ -1,6 +1,7 @@
 # planship-python
 
-Welcome to the Python client for [Planship](https://planship.io).
+Welcome to the Python client for the [Planship API](https://docs.planship.io/integration). [Planship](https://planship.io) enables developers to build subscription logic for product pricing based on any combination of features, seats, and usage.
+
 
 ## Installation and basic usage
 
@@ -19,7 +20,6 @@ from planship import Planship
 
 planship = Planship(
     "clicker-demo",                         # Planship product slug
-    "https://api.planship.io",              # Planship API endpoint URL
     "273N1SQ3GQFZ8JSFKIOK",                 # Planship API client ID
     "GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX"      # Planship API client secret
 )
@@ -33,20 +33,21 @@ customer = planship.create_customer({
     "email:": "vader@empire.gov"
 })
 
-# Subscribe the customer with a given ID to a plan with a slug "medium"
+# Subscribe the customer to a plan with the slug "medium"
 subscription = planship.create_subscription(customer.id, "medium")
 
-# Retrieve entitlements for a customer with a give ID
+# Retrieve entitlements for the customer
 entitlements = planship.get_entitlements(customer.id)
 
-# Report usage for a customer with given ID for a given metering ID
+# Report 11 units of usage for the "api-call" metering ID for the customer
 planship.report_usage(customer.id, "api-call", 11)
 ```
 
-The complete reference for the `Planship` class can be found [here](./docs/content/planship-class.md).
+The complete reference for the `Planship` class can be found [here](https://github.com/planship/planship-python/blob/master/docs/content/planship-class.md).
 
 ## Links
 
 - [Planship documentation](https://docs.planship.io)
+- [Sign up for Planship](https://app.planship.io/auth/sign-up)
+- [Planship Python client class reference](https://github.com/planship/planship-python/blob/master/docs/content/planship-class.md)
 - [Planship Python client at PyPI](https://pypi.org/project/planship/)
-- [Planship Console sign-up](https://app.planship.io/auth/sign-up)

--- a/planship/planship/base.py
+++ b/planship/planship/base.py
@@ -7,13 +7,13 @@ from .http_basic_auth_configuration import HttpBasicAuthConfiguration
 
 
 class Base:
-    _url: str
+    _baseUrl: str
     __client_id: str
     __client_secret: str
     __access_token: str = None
 
-    def __init__(self, url: str, client_id: str, client_secret: str):
-        self._url = url
+    def __init__(self, client_id: str, client_secret: str, baseUrl: str):
+        self._baseUrl = baseUrl
         self.__client_id = client_id
         self.__client_secret = client_secret
 
@@ -26,7 +26,7 @@ class Base:
             self.__refresh_access_token()
 
         configuration = planship_openapi_gen.Configuration(
-            host=self._url,
+            host=self._baseUrl,
             access_token=self.__access_token,
         )
 
@@ -38,7 +38,7 @@ class Base:
 
     def get_access_token(self) -> TokenResponse:
         configuration = HttpBasicAuthConfiguration(
-            host=self._url,
+            host=self._baseUrl,
             username=self.__client_id,
             password=self.__client_secret,
         )

--- a/planship/planship/planship.py
+++ b/planship/planship/planship.py
@@ -38,7 +38,14 @@ from .models import (
 
 
 class Planship(Base):
-    def __init__(self, product_slug: str, url: str, client_id: str, client_secret: str):
+    def __init__(
+        self,
+        product_slug: str,
+        client_id: str,
+        client_secret: str,
+        *,
+        baseUrl: str = "https://api.planship.io"
+    ):
         """Create an instance of the Planship API client class
 
         Args:
@@ -47,7 +54,9 @@ class Planship(Base):
             client_id (str): Planship API client ID
             client_secret (str): Planship API client secret
         """
-        super().__init__(url=url, client_id=client_id, client_secret=client_secret)
+        super().__init__(
+            client_id=client_id, client_secret=client_secret, baseUrl=baseUrl
+        )
         self.product_slug = product_slug
 
     def get_product(self) -> Product:

--- a/planship/setup.py
+++ b/planship/setup.py
@@ -6,7 +6,7 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 NAME = "planship"
-VERSION = "0.1.1"
+VERSION = "0.2.1"
 # To install the library, run the following
 #
 # python setup.py install
@@ -18,13 +18,19 @@ REQUIRES = [
     "planship_openapi_gen >= 1",
 ]
 
+project_urls = {
+    "Repository": "https://github.com/planship/planship-python",
+    "Planship Docs": "https://docs.planship.io",
+    "Class Reference": "https://github.com/planship/planship-python/blob/master/docs/content/planship-class.md",
+}
+
 setup(
     name=NAME,
     version=VERSION,
     description="Planship API client",
     author="Pawel Wojnarowicz",
     author_email="pawel@planship.io",
-    url="",
+    url="https://planship.io",
     keywords=["Planship"],
     python_requires=">=3.7",
     install_requires=REQUIRES,
@@ -32,4 +38,5 @@ setup(
     include_package_data=True,
     long_description=long_description,
     long_description_content_type="text/markdown",
+    project_urls=project_urls,
 )


### PR DESCRIPTION
This PR, when merged, will rename the `Planship` class `url` argument to `baseUrl`, and make it an optional keyword argument with the default value set to `https://api.planship.io`.

Other changes include minor tweaks to the README, setup.py and the Makefile.